### PR TITLE
Create the "GetName" endpoint

### DIFF
--- a/Api/Mappers/NamesControllerMappers.cs
+++ b/Api/Mappers/NamesControllerMappers.cs
@@ -11,25 +11,7 @@ namespace Api.Mappers
     {
         public static NameEntryDto[] MapToDtoCollection(this List<NameEntry> names)
         {
-            return names.Select(nameEntry => new NameEntryDto
-            {
-                Pronunciation = nameEntry.Pronunciation,
-                IpaNotation = nameEntry.IpaNotation,
-                Variants = nameEntry.Variants,
-                Syllables = nameEntry.Syllables,
-                Meaning = nameEntry.Meaning,
-                ExtendedMeaning = nameEntry.ExtendedMeaning,
-                Morphology = nameEntry.Morphology,
-                GeoLocation = nameEntry.GeoLocation.Select(ge => new GeoLocationDto(ge.Place, ge.Region)).ToList(),
-                FamousPeople = nameEntry.FamousPeople,
-                Media = nameEntry.Media,
-                SubmittedBy = nameEntry.CreatedBy,
-                Etymology = nameEntry.Etymology.Select(et => new EtymologyDto(et.Part, et.Meaning)).ToList(),
-                State = nameEntry.State,
-                CreatedAt = nameEntry.CreatedAt,
-                UpdatedAt = nameEntry.UpdatedAt,
-                Name = nameEntry.Name
-            }).ToArray();
+            return names.Select(nameEntry => MapToDto(nameEntry)).ToArray();
         }
 
         public static NameEntry MapToEntity(this CreateNameDto request)
@@ -51,6 +33,29 @@ namespace Api.Mappers
                 Syllables = request.Syllables ?? new List<string>(),
                 Variants = request.Variants ?? new List<string>(),
                 CreatedBy = request.SubmittedBy
+            };
+        }
+
+        public static NameEntryDto MapToDto(this NameEntry nameEntry)
+        {
+            return new NameEntryDto
+            {
+                Pronunciation = nameEntry.Pronunciation,
+                IpaNotation = nameEntry.IpaNotation,
+                Variants = nameEntry.Variants,
+                Syllables = nameEntry.Syllables,
+                Meaning = nameEntry.Meaning,
+                ExtendedMeaning = nameEntry.ExtendedMeaning,
+                Morphology = nameEntry.Morphology,
+                GeoLocation = nameEntry.GeoLocation.Select(ge => new GeoLocationDto(ge.Place, ge.Region)).ToList(),
+                FamousPeople = nameEntry.FamousPeople,
+                Media = nameEntry.Media,
+                SubmittedBy = nameEntry.CreatedBy,
+                Etymology = nameEntry.Etymology.Select(et => new EtymologyDto(et.Part, et.Meaning)).ToList(),
+                State = nameEntry.State,
+                CreatedAt = nameEntry.CreatedAt,
+                UpdatedAt = nameEntry.UpdatedAt,
+                Name = nameEntry.Name
             };
         }
     }

--- a/Application/Services/NameEntryService.cs
+++ b/Application/Services/NameEntryService.cs
@@ -136,5 +136,10 @@ namespace Application.Domain
             count = Math.Min(count ?? DefaultListCount, MaxListCount);
             return await _nameEntryRepository.List(pageNumber.Value, count.Value, ne => ne.State == state);
         }
+
+        public async Task<NameEntry?> LoadName(string name)
+        {
+            return await _nameEntryRepository.FindByName(name);
+        }
     }
 }


### PR DESCRIPTION
Notes: The query parameters 'duplicates' and 'feedback' were removed during the migration. This is because I noticed that the admin dashboard never requests with any of those parameters set to true.

Java function:
```java
/**
     * Get the details of a name
     * @param withDuplicates flag whether to return duplicate entries for the name being retrieved
     * @param name the name whose details needs to be retrieved
     * @return a name serialized to a jason string
     * @throws JsonProcessingException json processing exception
     */
    @RequestMapping(value = "/v1/names/{name}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
    public Object getName(@RequestParam("duplicates") final Optional<Boolean> withDuplicates,
                          @RequestParam("feedback") final Optional<Boolean> feedback,
                          @PathVariable String name) throws JsonProcessingException {
        NameEntry nameEntry = entryService.loadName(name);
        if (nameEntry == null) {
            String errorMsg = "#NAME not found in the database".replace("#NAME", name);
            throw new GenericApiCallException(errorMsg);
        }

        HashMap<String, Object> nameEntries = new HashMap<>();
        nameEntries.put("mainEntry", nameEntry);

        if (withDuplicates.isPresent() && (withDuplicates.get() == true)) {
            List<DuplicateNameEntry> duplicates = entryService.loadNameDuplicates(name);
            nameEntries.put("duplicates", duplicates);
        }

        if (feedback.isPresent() && (feedback.get() == true)) {
            nameEntries.put("feedback", entryService.getFeedback(nameEntry));
        }

        if (nameEntries.size() == 1 && nameEntries.get("mainEntry") != null) {
            return nameEntries.get("mainEntry");
        }

        return nameEntries;
    }
```