### PR TITLE
Feature/allow multiple entries with same letters

### DIFF
--- a/Api/Controllers/Names/AuthController.cs
+++ b/Api/Controllers/Names/AuthController.cs
@@ -44,11 +44,7 @@ namespace Api.Controllers.Names
         public async Task<IActionResult> Login()
         {
             var theUser = await _userService.GetUserByEmail(User.Identity!.Name!);
-            var userDetails = new UserDto
-            {
-                Roles = [.. theUser.Roles],
-                Username = theUser.Email,
-            };
+            var userDetails = new UserDto(theUser.Email!, theUser.Email, [.. theUser.Roles]);
 
             return Ok(userDetails);
         }
@@ -129,12 +125,7 @@ namespace Api.Controllers.Names
             var theUser = await _userService.GetUserByEmail(email);
             return theUser == null ?
                 NotFound(ResponseHelper.GetResponseDict("User was not found.")) :
-                Ok(new UserDto
-                {
-                    Email = theUser.Email!,
-                    Roles = theUser.Roles.ToArray(),
-                    Username = theUser.Username,
-                });
+                Ok(new UserDto(theUser.Email!, theUser.Username, theUser.Roles.ToArray()));
         }
     }
 }

--- a/Api/Controllers/Names/SearchController.cs
+++ b/Api/Controllers/Names/SearchController.cs
@@ -77,17 +77,18 @@ namespace Api.Controllers.Names
         }
 
         [HttpGet("{searchTerm}")]
-        [ProducesResponseType(typeof(NameEntryDto), (int)HttpStatusCode.OK)]
-        public async Task<IActionResult> SearchOne(string searchTerm)
+        [ProducesResponseType(typeof(IEnumerable<NameEntryDto>), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> SearchByTitle(string searchTerm)
         {
-            var nameEntry = (await searchService.GetEntry(searchTerm))?.MapToDto();
+            var titleLookup = await searchService.GetEntry(searchTerm);
+            var matches = titleLookup.Matches.MapToDtoCollection();
 
-            if(nameEntry != null)
+            if (matches.Length == 1)
             {
-                await eventPubService.PublishEvent(new ExactEntrySearched(nameEntry.Name, languageService.CurrentTenant));
+                await eventPubService.PublishEvent(new ExactEntrySearched(matches[0].Name, languageService.CurrentTenant));
             }
 
-            return Ok(nameEntry);
+            return Ok(matches);
         }
 
         /// <summary>

--- a/Api/Controllers/Words/SearchController.cs
+++ b/Api/Controllers/Words/SearchController.cs
@@ -91,17 +91,18 @@ namespace Api.Controllers.Words
         }
 
         [HttpGet("{searchTerm}")]
-        [ProducesResponseType(typeof(WordEntryDto), (int)HttpStatusCode.OK)]
-        public async Task<IActionResult> SearchOne(string searchTerm)
+        [ProducesResponseType(typeof(IEnumerable<WordEntryDto>), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> SearchByTitle(string searchTerm)
         {
-            var wordEntry = (await searchService.GetEntry(searchTerm))?.MapToDto();
+            var titleLookup = await searchService.GetEntry(searchTerm);
+            var matches = titleLookup.Matches.MapToDtoCollection();
 
-            if (wordEntry != null)
+            if (matches.Length == 1)
             {
-                await eventPubService.PublishEvent(new ExactEntrySearched(wordEntry.Word, languageService.CurrentTenant));
+                await eventPubService.PublishEvent(new ExactEntrySearched(matches[0].Word, languageService.CurrentTenant));
             }
 
-            return Ok(wordEntry);
+            return Ok(matches);
         }
 
         [HttpGet("activity")]

--- a/Application/Application.csproj
+++ b/Application/Application.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="FluentValidation" Version="11.9.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
     <PackageReference Include="MySqlConnector" Version="2.3.7" />
-    <PackageReference Include="YorubaOrganization.Application" Version="5.*" />
+    <PackageReference Include="YorubaOrganization.Application" Version="6.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />

--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="YorubaOrganization.Core" Version="5.*" />
+    <PackageReference Include="YorubaOrganization.Core" Version="6.*" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Words.Core\Words.Core.csproj" />

--- a/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
     <PackageReference Include="TweetinviAPI" Version="5.0.4" />
-    <PackageReference Include="YorubaOrganization.Infrastructure" Version="5.0.0" />
+    <PackageReference Include="YorubaOrganization.Infrastructure" Version="6.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Website/Pages/MultipleEntriesFound.cshtml
+++ b/Website/Pages/MultipleEntriesFound.cshtml
@@ -1,0 +1,53 @@
+@page "/entries/multiple"
+@model MultipleEntriesFoundModel
+@{
+    ViewData["Title"] = $"Multiple entries found for {Model.Query}";
+}
+
+@using Website.Resources
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Messages> Localizer
+
+@await Html.PartialAsync("Partials/_MiniSearchForm")
+
+<section id="content" class="py-5 bg-light">
+    <div class="container">
+        <div class="row g-5">
+
+            <div class="col-lg-8">
+                <div class="text-center mb-4 p-4 bg-white rounded-3 shadow-sm border">
+                    <i class="bi bi-list-ul display-4 text-muted opacity-50 mb-3"></i>
+                    <h3 class="fw-bold text-dark mb-2">
+                        Multiple entries found for
+                        <span class="text-warning intonation fst-italic">"@Model.Query"</span>
+                    </h3>
+                    <p class="text-muted mb-0">Select the exact name you meant from the options below.</p>
+                </div>
+
+                <div class="list-group shadow-sm border-0">
+                    @foreach (var name in Model.Matches)
+                    {
+                        <a href="/entries/@name.Name" class="list-group-item list-group-item-action p-4 border-0 border-bottom">
+                            <div class="d-flex w-100 justify-content-between align-items-center mb-1">
+                                <h5 class="mb-1 fw-bold text-primary intonation fs-4">@name.Name</h5>
+                                <i class="bi bi-chevron-right text-muted"></i>
+                            </div>
+                            <p class="mb-1 text-muted">
+                                <strong class="text-dark">Meaning:</strong> @(string.IsNullOrWhiteSpace(name.Meaning) ? "-" : name.Meaning)
+                            </p>
+                        </a>
+                    }
+                </div>
+            </div>
+
+            <div class="col-lg-4">
+                <div class="sticky-top" style="top: 100px;">
+                    <div class="card bg-white border-0 shadow-sm p-3">
+                        <h5 class="fw-bold mb-3 border-bottom pb-2">Browse Dictionary</h5>
+                        @await Html.PartialAsync("Partials/_Alphabets", @Model.Letters)
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+</section>

--- a/Website/Pages/MultipleEntriesFound.cshtml.cs
+++ b/Website/Pages/MultipleEntriesFound.cshtml.cs
@@ -1,15 +1,15 @@
 using Application.Services.MultiLanguage;
-using Words.Core.Dto.Response;
+using Core.Dto.Response;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
-using Words.Website.Pages.Shared;
-using Words.Website.Resources;
-using Words.Website.Services;
+using Website.Pages.Shared;
+using Website.Resources;
+using Website.Services;
 using YorubaOrganization.Application.Services;
 
-namespace Words.Website.Pages
+namespace Website.Pages
 {
-    public class SearchResultsModel(
+    public class MultipleEntriesFoundModel(
         IStringLocalizer<Messages> localizer,
         ILanguageService languageService,
         ApiService apiService) : BasePageModel(localizer, languageService)
@@ -18,31 +18,28 @@ namespace Words.Website.Pages
 
         [BindProperty(SupportsGet = true)]
         [FromQuery(Name = "q")]
-        public string? Query { get; set; } = null;
-        public WordEntryDto[] Words { get; set; } = [];
+        public string? Query { get; set; }
+
+        public NameEntryDto[] Matches { get; private set; } = [];
         public List<string> Letters { get; private set; } = [];
 
         public async Task<IActionResult> OnGet()
         {
             if (string.IsNullOrWhiteSpace(Query))
             {
-                // TODO: Create an event to indicate that this page was accessed without a query parameter.
                 return RedirectToPage("Index");
             }
 
-            var exactMatches = await _apiService.GetWordsByTitle(Query) ?? [];
-            if (exactMatches.Length == 1)
+            Matches = await _apiService.GetNamesByTitle(Query);
+            if (Matches.Length == 0)
             {
-                return RedirectToPage("SingleEntry", new { wordEntry = exactMatches[0].Word });
+                return RedirectToPage("SearchResults", new { q = Query });
             }
 
-            if (exactMatches.Length > 1)
+            if (Matches.Length == 1)
             {
-                return RedirectToPage("MultipleEntriesFound", new { q = Query });
+                return RedirectToPage("SingleEntry", new { nameEntry = Matches[0].Name });
             }
-
-            var searchResult = await _apiService.SearchWordAsync(Query);
-            Words = searchResult ?? [];
 
             Letters = YorubaAlphabetService.YorubaAlphabet;
             return Page();

--- a/Website/Pages/SearchResults.cshtml.cs
+++ b/Website/Pages/SearchResults.cshtml.cs
@@ -2,7 +2,6 @@ using Application.Services.MultiLanguage;
 using Core.Dto.Response;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
-using System.Globalization;
 using Website.Pages.Shared;
 using Website.Resources;
 using Website.Services;
@@ -25,29 +24,28 @@ namespace Website.Pages
 
         public async Task<IActionResult> OnGet()
         {
-            if (Query == null)
+            if (string.IsNullOrWhiteSpace(Query))
             {
                 // TODO: Create an event to indicate that this page was accessed without a query parameter.
                 return RedirectToPage("Index");
             }
 
-            Names = await _apiService.SearchNameAsync(Query);
-
-            if (Names.Length == 1 && IsEqualWithoutAccent(Names[0].Name, Query))
+            var exactMatches = await _apiService.GetNamesByTitle(Query);
+            if (exactMatches.Length == 1)
             {
-                // TODO: Pass this name to the other page
-                return RedirectToPage("SingleEntry", new { nameEntry = Query });
+                // TODO Hafiz: Pass the entire name entry instead of just the name to avoid another API call in the SingleEntry page.
+                return RedirectToPage("SingleEntry", new { nameEntry = exactMatches[0].Name });
             }
+
+            if (exactMatches.Length > 1)
+            {
+                return RedirectToPage("MultipleEntriesFound", new { q = Query });
+            }
+
+            Names = await _apiService.SearchNameAsync(Query);
 
             Letters = YorubaAlphabetService.YorubaAlphabet;
             return Page();
-        }
-
-        private static bool IsEqualWithoutAccent(string string1, string string2)
-        {
-            CompareInfo compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-            int result = compareInfo.Compare(string1, string2, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace);
-            return result == 0;
         }
     }
 }

--- a/Website/Pages/SingleEntry.cshtml.cs
+++ b/Website/Pages/SingleEntry.cshtml.cs
@@ -25,12 +25,19 @@ namespace Website.Pages
         public async Task<IActionResult> OnGet(string nameEntry)
         {
             // TODO: Try to get name from search page first.
-            NameEntryDto? name = await _apiService.GetName(nameEntry);
+            var matches = await _apiService.GetNamesByTitle(nameEntry);
 
-            if (name == null)
+            if (matches.Length == 0)
             {
                 return Redirect($"/entries?q={HttpUtility.UrlEncode(nameEntry)}");
             }
+
+            if (matches.Length > 1)
+            {
+                return RedirectToPage("MultipleEntriesFound", new { q = nameEntry });
+            }
+
+            var name = matches[0];
 
             ViewData["SocialTitle"] = name.Name;
             ViewData["SocialPath"] = $"/entries/{HttpUtility.UrlEncode(name.Name)}";

--- a/Website/Services/ApiService.cs
+++ b/Website/Services/ApiService.cs
@@ -61,9 +61,9 @@ namespace Website.Services
             return GetApiResponse<NameEntryDto[]>("/search/?q=" + query)!;
         }
 
-        public Task<NameEntryDto?> GetName(string nameEntry)
+        public Task<NameEntryDto[]> GetNamesByTitle(string nameEntry)
         {
-            return GetApiResponse<NameEntryDto?>($"/search/{nameEntry}");
+            return GetApiResponse<NameEntryDto[]>($"/search/{Uri.EscapeDataString(nameEntry)}")!;
         }
 
         public Task<NameEntryDto[]> GetAllNamesByAlphabet(string letter)

--- a/Words.Core/Entities/WordEntry.cs
+++ b/Words.Core/Entities/WordEntry.cs
@@ -8,7 +8,7 @@ namespace Words.Core.Entities
         public Style? Style { get; set; }
         public GrammaticalFeature? GrammaticalFeature { get; set; }
 
-        public List<Definition> Definitions { get; set; }
+        public List<Definition> Definitions { get; set; } = [];
 
         // TODO YDict Later: Fields to re-adopt: InOtherLanguages, TonalMark, Tags
 

--- a/Words.Core/Words.Core.csproj
+++ b/Words.Core/Words.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="YorubaOrganization.Core" Version="5.*" />
+    <PackageReference Include="YorubaOrganization.Core" Version="6.*" />
   </ItemGroup>
 
 </Project>

--- a/Words.Website/Pages/MultipleEntriesFound.cshtml
+++ b/Words.Website/Pages/MultipleEntriesFound.cshtml
@@ -1,0 +1,38 @@
+@page "/entries/multiple"
+@using Words.Website.Resources
+@using Words.Core.Dto.Response
+@model Words.Website.Pages.MultipleEntriesFoundModel
+@{
+    ViewData["Title"] = "Multiple Entries Found";
+}
+
+@inject Microsoft.Extensions.Localization.IStringLocalizer<Messages> Localizer
+
+@await Html.PartialAsync("Partials/_MiniSearchForm")
+
+<section id="content">
+    <div class="container">
+        <div class="row">
+
+            <div class="col-sm-7 search-results">
+                <h4>
+                    Multiple entries found for
+                    <strong class="intonation"><i>@Model.Query</i></strong>
+                </h4>
+                <p>Select the exact word you meant from the options below.</p>
+
+                @foreach (WordEntryDto word in Model.Matches)
+                {
+                    DefinitionDto? firstDefinition = word.Definitions?.FirstOrDefault();
+
+                    <hr>
+                    <h4 class="strong-text intonation"><a href="/entries/@word.Word">@word.Word</a></h4>
+                    <p><strong>@Localizer["topDefinition"]: </strong> @(firstDefinition?.Content ?? "-")</p>
+                    <p><strong>@Localizer["english-translation"]: </strong> @(firstDefinition?.EnglishTranslation ?? "-")</p>
+                }
+            </div>
+
+            @await Html.PartialAsync("Partials/_Alphabets", Model.Letters)
+        </div>
+    </div>
+</section>

--- a/Words.Website/Pages/MultipleEntriesFound.cshtml.cs
+++ b/Words.Website/Pages/MultipleEntriesFound.cshtml.cs
@@ -1,7 +1,7 @@
 using Application.Services.MultiLanguage;
-using Words.Core.Dto.Response;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Localization;
+using Words.Core.Dto.Response;
 using Words.Website.Pages.Shared;
 using Words.Website.Resources;
 using Words.Website.Services;
@@ -9,7 +9,7 @@ using YorubaOrganization.Application.Services;
 
 namespace Words.Website.Pages
 {
-    public class SearchResultsModel(
+    public class MultipleEntriesFoundModel(
         IStringLocalizer<Messages> localizer,
         ILanguageService languageService,
         ApiService apiService) : BasePageModel(localizer, languageService)
@@ -18,31 +18,28 @@ namespace Words.Website.Pages
 
         [BindProperty(SupportsGet = true)]
         [FromQuery(Name = "q")]
-        public string? Query { get; set; } = null;
-        public WordEntryDto[] Words { get; set; } = [];
+        public string? Query { get; set; }
+
+        public WordEntryDto[] Matches { get; private set; } = [];
         public List<string> Letters { get; private set; } = [];
 
         public async Task<IActionResult> OnGet()
         {
             if (string.IsNullOrWhiteSpace(Query))
             {
-                // TODO: Create an event to indicate that this page was accessed without a query parameter.
                 return RedirectToPage("Index");
             }
 
-            var exactMatches = await _apiService.GetWordsByTitle(Query) ?? [];
-            if (exactMatches.Length == 1)
+            Matches = await _apiService.GetWordsByTitle(Query) ?? [];
+            if (Matches.Length == 0)
             {
-                return RedirectToPage("SingleEntry", new { wordEntry = exactMatches[0].Word });
+                return RedirectToPage("SearchResults", new { q = Query });
             }
 
-            if (exactMatches.Length > 1)
+            if (Matches.Length == 1)
             {
-                return RedirectToPage("MultipleEntriesFound", new { q = Query });
+                return RedirectToPage("SingleEntry", new { wordEntry = Matches[0].Word });
             }
-
-            var searchResult = await _apiService.SearchWordAsync(Query);
-            Words = searchResult ?? [];
 
             Letters = YorubaAlphabetService.YorubaAlphabet;
             return Page();

--- a/Words.Website/Pages/SingleEntry.cshtml.cs
+++ b/Words.Website/Pages/SingleEntry.cshtml.cs
@@ -24,12 +24,19 @@ namespace Words.Website.Pages
         public async Task<IActionResult> OnGet(string wordEntry)
         {
             // Try to get word from API
-            WordEntryDto? word = await _apiService.GetWord(wordEntry);
+            var matches = await _apiService.GetWordsByTitle(wordEntry) ?? [];
 
-            if (word == null)
+            if (matches.Length == 0)
             {
                 return Redirect($"/entries?q={HttpUtility.UrlEncode(wordEntry)}");
             }
+
+            if (matches.Length > 1)
+            {
+                return RedirectToPage("MultipleEntriesFound", new { q = wordEntry });
+            }
+
+            var word = matches[0];
 
             ViewData["SocialTitle"] = word.Word;
             ViewData["SocialPath"] = $"/entries/{HttpUtility.UrlEncode(word.Word)}";

--- a/Words.Website/Services/ApiService.cs
+++ b/Words.Website/Services/ApiService.cs
@@ -53,9 +53,9 @@ namespace Words.Website.Services
             }
         }
 
-        public Task<WordEntryDto?> GetWord(string wordEntry)
+        public Task<WordEntryDto[]?> GetWordsByTitle(string wordEntry)
         {
-            return GetApiResponse<WordEntryDto?>($"/words/search/{wordEntry}");
+            return GetApiResponse<WordEntryDto[]?>($"/words/search/{Uri.EscapeDataString(wordEntry)}");
         }
 
         public Task<WordEntryDto[]?> GetAllWordsByAlphabet(string letter)


### PR DESCRIPTION
At the moment, the dictionary cannot hold homograph entries. It means that if we have the two names below:
- oko (Farm)
- ọkọ (Husband)

Once the first one is in the dictionary, we cannot add the second one. This change removes that limitation since there are a lot of homographs in the Yoruba language.