### PR TITLE
Deployment: word manager fix cors issue

### DIFF
--- a/Server/nginx.conf
+++ b/Server/nginx.conf
@@ -324,6 +324,8 @@ http {
             proxy_cache_bypass $http_upgrade;
         }
 
-        # SSL certificate section intentionally omitted as requested
+        ssl_certificate /etc/letsencrypt/live/www.yorubaword.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/www.yorubaword.com/privkey.pem;
+        include /etc/letsencrypt/options-ssl-nginx.conf;
     }
 }

--- a/Server/nginx.conf
+++ b/Server/nginx.conf
@@ -286,10 +286,32 @@ http {
         ssl_certificate_key /etc/letsencrypt/live/tts.yorubaname.com/privkey.pem; # managed by Certbot
     }
 
-    # Production server block for yorubaword.com (no /api, /analytics, or /analytics/ws)
+    # Production server block for yorubaword.com
     server {
         listen 443 ssl;
         server_name yorubaword.com www.yorubaword.com;
+
+        location /api {
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' "$dashboard_url" always;
+                add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS' always;
+                add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization' always;
+                add_header 'Content-Length' 0;
+                add_header 'Content-Type' 'text/plain';
+                return 204;
+            }
+            add_header 'Access-Control-Allow-Origin' "$dashboard_url" always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, PATCH, DELETE, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Origin, X-Requested-With, Content-Type, Accept, Authorization' always;
+            proxy_pass http://localhost:1990/api;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection keep-alive;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+        }
 
         location / {
             proxy_pass http://localhost:1992;


### PR DESCRIPTION
The dashboard which relies on the dictionary API for data was unable to send request to the website due to CORS blocking.

The NGINX server is reconfigured to address this problem.