### PR TITLE
Get the latest patch version of YOrg projects which fixes autcomplete issue

### DIFF
--- a/Api/packages.lock.json
+++ b/Api/packages.lock.json
@@ -920,8 +920,8 @@
       },
       "YorubaOrganization.Core": {
         "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }

--- a/Application/packages.lock.json
+++ b/Application/packages.lock.json
@@ -188,8 +188,8 @@
       },
       "YorubaOrganization.Core": {
         "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }

--- a/Core/packages.lock.json
+++ b/Core/packages.lock.json
@@ -5,8 +5,8 @@
       "YorubaOrganization.Core": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }

--- a/Infrastructure/packages.lock.json
+++ b/Infrastructure/packages.lock.json
@@ -877,8 +877,8 @@
       },
       "YorubaOrganization.Core": {
         "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }

--- a/Test/packages.lock.json
+++ b/Test/packages.lock.json
@@ -1718,8 +1718,8 @@
       },
       "YorubaOrganization.Core": {
         "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }

--- a/Website/packages.lock.json
+++ b/Website/packages.lock.json
@@ -228,8 +228,8 @@
       },
       "YorubaOrganization.Core": {
         "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }

--- a/Words.Core/packages.lock.json
+++ b/Words.Core/packages.lock.json
@@ -5,8 +5,8 @@
       "YorubaOrganization.Core": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }

--- a/Words.Website/packages.lock.json
+++ b/Words.Website/packages.lock.json
@@ -228,8 +228,8 @@
       },
       "YorubaOrganization.Core": {
         "type": "Transitive",
-        "resolved": "6.0.3",
-        "contentHash": "mPB9Hqv87F2wvk/aHPjwNmEYg+AGPyQZto2VhhSkJdho6TuhXkWtpMPfl92txLLJu2/NQET22c05A2byttyQLg==",
+        "resolved": "6.0.4",
+        "contentHash": "tKJvdIuorsbtpEO2g+JjbIUVBfqTKSYjfzbkq7NnmpMOp2T8rSBAtEY1p/f7nvO7LBRSswxYRpHrflC5OOWn/g==",
         "dependencies": {
           "MediatR.Contracts": "2.0.1"
         }


### PR DESCRIPTION
Autocomplete was not matching for words having the ń character. The latest version of YorubaOrganization.Core fixes the problem by using a more wide-catching regex for the search.