### PR TITLE
Feature/english definitions management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# Language Server Protocol cache files
+*.lscache

--- a/Api/Configuration/WordsApiConfig.cs
+++ b/Api/Configuration/WordsApiConfig.cs
@@ -1,0 +1,7 @@
+namespace Api.Configuration
+{
+    public record WordsApiConfig
+    {
+        public required string BaseUrl { get; init; }
+    }
+}

--- a/Api/Controllers/Names/EtymologyController.cs
+++ b/Api/Controllers/Names/EtymologyController.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using System.Text.Json;
 using YorubaOrganization.Core.Repositories;
 
 namespace Api.Controllers.Names
@@ -7,14 +9,20 @@ namespace Api.Controllers.Names
     [ApiController]
     public class EtymologyController : ControllerBase
     {
-        private readonly IEtymologyRepository _etymologyRepository;
+        private const string WordsDefinitionsInEnglishPath = "/api/v1/words/definitions/in-english";
 
-        public EtymologyController(IEtymologyRepository etymologyRepository)
+        private readonly IEtymologyRepository _etymologyRepository;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public EtymologyController(IEtymologyRepository etymologyRepository,
+            IHttpClientFactory httpClientFactory)
         {
             _etymologyRepository = etymologyRepository;
+            _httpClientFactory = httpClientFactory;
         }
 
         [HttpGet("latest-meaning")]
+        [Obsolete("This endpoint has been replaced with the GET meanings endpoint")]
         public async Task<IActionResult> GetLatestMeaning([FromQuery] string parts)
         {
             if (string.IsNullOrWhiteSpace(parts))
@@ -25,6 +33,87 @@ namespace Api.Controllers.Names
             var partsList = parts.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim());
             var result = await _etymologyRepository.GetLatestMeaningOf(partsList);
             return Ok(result);
+        }
+
+        [HttpGet("meanings")]
+        public async Task<IActionResult> GetMeanings([FromQuery] string parts)
+        {
+            if (string.IsNullOrWhiteSpace(parts))
+            {
+                return BadRequest("Parts parameter is required.");
+            }
+
+            var partsList = parts
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.CurrentCultureIgnoreCase)
+                .ToArray();
+
+            if (partsList.Length == 0)
+            {
+                return BadRequest("At least one part is required.");
+            }
+
+            var wordsParam = string.Join(',', partsList);
+            var requestUrl = $"{WordsDefinitionsInEnglishPath}?words={Uri.EscapeDataString(wordsParam)}";
+
+            var response = await SendProxyRequestAsync(HttpMethod.Get, requestUrl);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return StatusCode((int)response.StatusCode, "Failed to fetch etymology meanings from Words API.");
+            }
+
+            var payload = await response.Content.ReadFromJsonAsync<IDictionary<string, string[]>>(new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            return Ok(payload ?? new Dictionary<string, string[]>());
+        }
+
+        [HttpPost("meanings")]
+        [Authorize(Policy = "AdminAndLexicographers")]
+        public async Task<IActionResult> AddMeanings([FromBody] IDictionary<string, string>? payload)
+        {
+            if (payload == null || payload.Count == 0)
+            {
+                return BadRequest("Payload must be a dictionary of part to English definition.");
+            }
+
+            var response = await SendProxyRequestAsync(HttpMethod.Post, WordsDefinitionsInEnglishPath, JsonContent.Create(payload));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return StatusCode((int)response.StatusCode, "Failed to submit new etymology meanings to Words API.");
+            }
+
+            var responsePayload = await response.Content.ReadFromJsonAsync<Dictionary<string, object>>(new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+
+            return Ok(responsePayload ?? []);
+        }
+
+        private async Task<HttpResponseMessage> SendProxyRequestAsync(HttpMethod method, string requestUrl, HttpContent? content = null)
+        {
+            var client = _httpClientFactory.CreateClient("WordsApiClient");
+            using var requestMessage = new HttpRequestMessage(method, requestUrl)
+            {
+                Content = content
+            };
+
+            ForwardAuthorizationHeader(requestMessage);
+            return await client.SendAsync(requestMessage);
+        }
+
+        private void ForwardAuthorizationHeader(HttpRequestMessage requestMessage)
+        {
+            if (Request.Headers.TryGetValue("Authorization", out var authorizationHeader)
+                && !string.IsNullOrWhiteSpace(authorizationHeader))
+            {
+                requestMessage.Headers.TryAddWithoutValidation("Authorization", authorizationHeader.ToString());
+            }
         }
     }
 }

--- a/Api/Controllers/Words/DefinitionsController.cs
+++ b/Api/Controllers/Words/DefinitionsController.cs
@@ -2,6 +2,7 @@ using Application.Services.Words;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
+using Words.Core.Dto.Response;
 
 namespace Api.Controllers.Words
 {
@@ -10,6 +11,10 @@ namespace Api.Controllers.Words
     [Authorize(Policy = "AdminAndLexicographers")]
     public class DefinitionsController(WordEntryService entryService) : ControllerBase
     {
+        private const int DefaultPage = 1;
+        private const int DefaultCount = 50;
+        private const int MaxCount = 500;
+
         /// <summary>
         /// Returns English definitions for each requested word, irrespective of review status.
         /// </summary>
@@ -50,6 +55,26 @@ namespace Api.Controllers.Words
             var response = statuses.ToDictionary(kvp => kvp.Key, kvp => (object)new { status = kvp.Value });
 
             return Ok(response);
+        }
+
+        /// <summary>
+        /// Lists words that contain at least one definition needing review.
+        /// </summary>
+        [HttpGet("needs-review")]
+        [ProducesResponseType(typeof(List<WordDefinitionNeedsReviewDto>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> GetWordsWithDefinitionsNeedingReview([FromQuery] int? page, [FromQuery] int? count)
+        {
+            var pageNumber = page ?? DefaultPage;
+            var pageSize = Math.Min(count ?? DefaultCount, MaxCount);
+
+            if (pageNumber < 1 || pageSize < 1)
+            {
+                return BadRequest("page and count must be greater than 0.");
+            }
+
+            var result = await entryService.GetWordsWithDefinitionsNeedingReviewAsync(pageNumber, pageSize);
+            return Ok(result);
         }
     }
 }

--- a/Api/Controllers/Words/DefinitionsController.cs
+++ b/Api/Controllers/Words/DefinitionsController.cs
@@ -51,7 +51,8 @@ namespace Api.Controllers.Words
                 return BadRequest("Payload must be a dictionary of word to English definition.");
             }
 
-            var statuses = await entryService.AddEnglishDefinitionsAsync(payload);
+            var currentUser = User?.Identity?.Name;
+            var statuses = await entryService.AddEnglishDefinitionsAsync(payload, currentUser);
             var response = statuses.ToDictionary(kvp => kvp.Key, kvp => (object)new { status = kvp.Value });
 
             return Ok(response);

--- a/Api/Controllers/Words/DefinitionsController.cs
+++ b/Api/Controllers/Words/DefinitionsController.cs
@@ -1,0 +1,55 @@
+using Application.Services.Words;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace Api.Controllers.Words
+{
+    [Route("api/v1/words/[controller]")]
+    [ApiController]
+    [Authorize(Policy = "AdminAndLexicographers")]
+    public class DefinitionsController(WordEntryService entryService) : ControllerBase
+    {
+        /// <summary>
+        /// Returns English definitions for each requested word, irrespective of review status.
+        /// </summary>
+        [HttpGet("in-english")]
+        [AllowAnonymous]
+        [ProducesResponseType(typeof(IDictionary<string, string[]>), (int)HttpStatusCode.OK)]
+        public async Task<IActionResult> GetEnglishDefinitions([FromQuery] string words)
+        {
+            if (string.IsNullOrWhiteSpace(words))
+            {
+                return BadRequest("At least one word is required in query parameter words.");
+            }
+
+            var requestedWords = words
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Distinct(StringComparer.CurrentCultureIgnoreCase)
+                .ToArray();
+
+            var result = await entryService.GetEnglishDefinitionsOf(requestedWords);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Adds English definitions that do not already exist for each supplied word.
+        /// New definitions created via this endpoint are marked as needing review.
+        /// </summary>
+        [HttpPost("in-english")]
+        [ProducesResponseType(typeof(IDictionary<string, object>), (int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> AddEnglishDefinitions([FromBody] IDictionary<string, string>? payload)
+        {
+            if (payload == null || payload.Count == 0)
+            {
+                return BadRequest("Payload must be a dictionary of word to English definition.");
+            }
+
+            var statuses = await entryService.AddEnglishDefinitionsAsync(payload);
+            var response = statuses.ToDictionary(kvp => kvp.Key, kvp => (object)new { status = kvp.Value });
+
+            return Ok(response);
+        }
+    }
+}

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -29,6 +29,7 @@ using Core.Entities;
 using Words.Core.Entities;
 using SuggestedNamesService = Application.Services.Names.SuggestionsService;
 using SuggestedWordsService = Application.Services.Words.SuggestionsService;
+using Microsoft.Extensions.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = builder.Configuration;
@@ -131,6 +132,19 @@ services
 
 // Words
 services.Configure<WordsConfig>(configuration.GetSection("Words"));
+services.Configure<WordsApiConfig>(configuration.GetSection("WordsApi"));
+services.AddHttpClient("WordsApiClient", (serviceProvider, client) =>
+{
+    var wordsApiConfig = serviceProvider.GetRequiredService<IOptions<WordsApiConfig>>().Value;
+    var baseUrl = wordsApiConfig.BaseUrl?.TrimEnd('/') ?? string.Empty;
+
+    if (baseUrl.EndsWith("/api", StringComparison.CurrentCultureIgnoreCase))
+    {
+        baseUrl = baseUrl[..^4];
+    }
+
+    client.BaseAddress = new Uri(baseUrl);
+});
 services
     .AddScoped<EntryFeedbackService<WordEntry>>()
     .AddScoped<WordFeedbackService>()

--- a/Api/appsettings.Development.json
+++ b/Api/appsettings.Development.json
@@ -20,5 +20,8 @@
   },
   "Redis": {
     "DatabaseIndex": 1
+  },
+  "WordsApi": {
+    "BaseUrl": "http://local.yorubaword.com"
   }
 }

--- a/Application/Mappers/Words/WordEntryMapper.cs
+++ b/Application/Mappers/Words/WordEntryMapper.cs
@@ -53,7 +53,8 @@ namespace Application.Mappers.Words
                         .Select(example =>
                         new DefinitionExampleDto(example.Content, example.EnglishTranslation, example.Type)
                         )],
-                definition.CreatedAt
+                definition.CreatedAt,
+                definition.NeedsReview
             );
         }
 
@@ -78,6 +79,7 @@ namespace Application.Mappers.Words
                 {
                     Content = d.Content,
                     EnglishTranslation = d.EnglishTranslation,
+                    NeedsReview = d.NeedsReview,
                     Examples = d.Examples?.Select(ex => new DefinitionExample
                     {
                         Content = ex.Content,
@@ -110,7 +112,8 @@ namespace Application.Mappers.Words
                                         d.Content,
                                         d.EnglishTranslation,
                                         [.. d.Examples.Select(ex => new DefinitionExampleDto(ex.Content, ex.EnglishTranslation, ex.Type))],
-                                        d.CreatedAt)
+                                        d.CreatedAt,
+                                        d.NeedsReview)
                                     )],
             })];
         }

--- a/Application/Services/Words/WordEntryService.cs
+++ b/Application/Services/Words/WordEntryService.cs
@@ -16,7 +16,18 @@ namespace Application.Services.Words
         DictionaryEntryService<WordEntry>(wordEntryRepository, eventPubService, tenantProvider, logger)
     {
         private readonly IEventPubService _eventPubService = eventPubService;
+        private readonly IWordEntryRepository _wordEntryRepository = wordEntryRepository;
         private readonly string _currentTenant = tenantProvider.GetCurrentTenant();
+
+        public Task<IDictionary<string, string[]>> GetEnglishDefinitionsOf(IEnumerable<string> words)
+        {
+            return _wordEntryRepository.GetEnglishDefinitionsOf(words);
+        }
+
+        public Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord)
+        {
+            return _wordEntryRepository.AddEnglishDefinitionsAsync(definitionsByWord);
+        }
 
         public async Task<List<WordEntry>> BulkUpdateWords(List<WordEntry> wordEntries)
         {

--- a/Application/Services/Words/WordEntryService.cs
+++ b/Application/Services/Words/WordEntryService.cs
@@ -1,5 +1,6 @@
 using Core.Events;
 using Microsoft.Extensions.Logging;
+using Words.Core.Dto.Response;
 using Words.Core.Entities;
 using Words.Core.Repositories;
 using YorubaOrganization.Application.Services;
@@ -27,6 +28,11 @@ namespace Application.Services.Words
         public Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord)
         {
             return _wordEntryRepository.AddEnglishDefinitionsAsync(definitionsByWord);
+        }
+
+        public Task<List<WordDefinitionNeedsReviewDto>> GetWordsWithDefinitionsNeedingReviewAsync(int page, int count)
+        {
+            return _wordEntryRepository.GetWordsWithDefinitionsNeedingReviewAsync(page, count);
         }
 
         public async Task<List<WordEntry>> BulkUpdateWords(List<WordEntry> wordEntries)

--- a/Application/Services/Words/WordEntryService.cs
+++ b/Application/Services/Words/WordEntryService.cs
@@ -22,12 +22,12 @@ namespace Application.Services.Words
 
         public Task<IDictionary<string, string[]>> GetEnglishDefinitionsOf(IEnumerable<string> words)
         {
-            return _wordEntryRepository.GetEnglishDefinitionsOf(words);
+            return _wordEntryRepository.GetEnglishDefinitionsOfAsync(words);
         }
 
-        public Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord)
+        public Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord, string? currentUser = null)
         {
-            return _wordEntryRepository.AddEnglishDefinitionsAsync(definitionsByWord);
+            return _wordEntryRepository.AddEnglishDefinitionsAsync(definitionsByWord, currentUser);
         }
 
         public Task<List<WordDefinitionNeedsReviewDto>> GetWordsWithDefinitionsNeedingReviewAsync(int page, int count)

--- a/Infrastructure/MongoDB/Repositories/Words/WordRepository.cs
+++ b/Infrastructure/MongoDB/Repositories/Words/WordRepository.cs
@@ -8,13 +8,30 @@ using YorubaOrganization.Core.Enums;
 using YorubaOrganization.Core.Utilities;
 using MongoDB.Bson;
 using Words.Core.Repositories;
+using Words.Core.Dto.Response;
 
 namespace Infrastructure.MongoDB.Repositories.Words
 {
-    public class WordRepository(IMongoDatabaseFactory databaseFactory, ITenantProvider tenantProvider, IEventPubService eventPubService) : DictionaryEntryRepository<WordEntry>(CollectionName, databaseFactory, tenantProvider, eventPubService), IWordEntryRepository
+    public class WordRepository : DictionaryEntryRepository<WordEntry>, IWordEntryRepository
     {
         private const string CollectionName = "Words";
         private const string YorubaDefinitionPlaceholder = "{{YORUBA-DEFINITION-PLACEHOLDER}}";
+        private const string DefinitionsNeedsReviewStateIndexName = "idx_words_definitions_needsreview_state";
+        private static readonly object IndexCreationLock = new();
+        private static bool _DoesWordDefinitionsNeedingReviewIndexExist;
+
+        public WordRepository(IMongoDatabaseFactory databaseFactory, ITenantProvider tenantProvider, IEventPubService eventPubService)
+            : base(CollectionName, databaseFactory, tenantProvider, eventPubService)
+        {
+            EnsureIndexesCreated();
+        }
+
+        private sealed class UnwoundWordDefinition
+        {
+            public string Title { get; set; } = string.Empty;
+            public State State { get; set; }
+            public Definition Definitions { get; set; } = null!;
+        }
 
         public async Task<int> CountByStateAsync(State state)
         {
@@ -218,6 +235,31 @@ namespace Infrastructure.MongoDB.Repositories.Words
             return statuses;
         }
 
+        public async Task<List<WordDefinitionNeedsReviewDto>> GetWordsWithDefinitionsNeedingReviewAsync(int page, int count)
+        {
+            page = Math.Max(1, page);
+            count = Math.Max(1, count);
+            var skip = (page - 1) * count;
+
+            var aggregated = await RepoCollection
+                .Aggregate(SetCollationSecondary<AggregateOptions>(new AggregateOptions()))
+                .Unwind<WordEntry, UnwoundWordDefinition>(w => w.Definitions)
+                .Match(x => x.Definitions.NeedsReview == true)
+                .Group(
+                    x => new { x.Title, x.State },
+                    g => new WordDefinitionNeedsReviewDto(
+                        g.Key.State,
+                        g.Key.Title,
+                        g.Max(x => x.Definitions.CreatedAt),
+                        g.Count()))
+                .SortByDescending(x => x.LastDefinitionAddedAt)
+                .Skip(skip)
+                .Limit(count)
+                .ToListAsync();
+
+            return aggregated;
+        }
+
         private async Task CreateWord(KeyValuePair<string, string> request)
         {
             var newWordEntry = new WordEntry
@@ -233,6 +275,34 @@ namespace Infrastructure.MongoDB.Repositories.Words
             };
 
             await RepoCollection.InsertOneAsync(newWordEntry);
+        }
+
+        private bool EnsureIndexesCreated()
+        {
+            if (_DoesWordDefinitionsNeedingReviewIndexExist)
+            {
+                return true;
+            }
+
+            lock (IndexCreationLock)
+            {
+                if (_DoesWordDefinitionsNeedingReviewIndexExist)
+                {
+                    return true;
+                }
+
+                var indexKeys = Builders<WordEntry>.IndexKeys
+                    .Ascending("Definitions.NeedsReview")
+                    .Ascending(x => x.State);
+
+                var indexModel = new CreateIndexModel<WordEntry>(
+                    indexKeys,
+                    new CreateIndexOptions { Name = DefinitionsNeedsReviewStateIndexName });
+
+                RepoCollection.Indexes.CreateOne(indexModel);
+                _DoesWordDefinitionsNeedingReviewIndexExist = true;
+                return true;
+            }
         }
 
         // TODO YDict: Implement the custom FindBy methods (which are commented out in the interface) here (based on definitions).

--- a/Infrastructure/MongoDB/Repositories/Words/WordRepository.cs
+++ b/Infrastructure/MongoDB/Repositories/Words/WordRepository.cs
@@ -14,6 +14,7 @@ namespace Infrastructure.MongoDB.Repositories.Words
     public class WordRepository(IMongoDatabaseFactory databaseFactory, ITenantProvider tenantProvider, IEventPubService eventPubService) : DictionaryEntryRepository<WordEntry>(CollectionName, databaseFactory, tenantProvider, eventPubService), IWordEntryRepository
     {
         private const string CollectionName = "Words";
+        private const string YorubaDefinitionPlaceholder = "{{YORUBA-DEFINITION-PLACEHOLDER}}";
 
         public async Task<int> CountByStateAsync(State state)
         {
@@ -115,6 +116,123 @@ namespace Infrastructure.MongoDB.Repositories.Words
             & Builders<WordEntry>.Filter.Eq(ne => ne.State, state);
             var result = await RepoCollection.Find(filter).ToListAsync();
             return [.. result];
+        }
+
+        public async Task<IDictionary<string, string[]>> GetEnglishDefinitionsOf(IEnumerable<string> words)
+        {
+            var requestedWords = words
+                .Where(w => !string.IsNullOrWhiteSpace(w))
+                .Select(w => w.Trim())
+                .Distinct(StringComparer.CurrentCultureIgnoreCase)
+                .ToArray();
+
+            if (requestedWords.Length == 0)
+            {
+                return new Dictionary<string, string[]>();
+            }
+
+            var matchingWords = await RepoCollection
+                .Find(Builders<WordEntry>.Filter.In(w => w.Title, requestedWords), SetCollationSecondary<FindOptions>(new FindOptions()))
+                .Project(w => new
+                {
+                    w.Title,
+                    w.Definitions
+                })
+                .ToListAsync();
+
+            var result = requestedWords.ToDictionary(
+                keySelector: word => word,
+                elementSelector: _ => Array.Empty<string>());
+
+            foreach (var matchingWord in matchingWords)
+            {
+                var englishDefinitions = matchingWord.Definitions
+                    .Where(d => !string.IsNullOrWhiteSpace(d.EnglishTranslation))
+                    .Select(d => d.EnglishTranslation!.Trim())
+                    .Distinct(StringComparer.CurrentCultureIgnoreCase)
+                    .ToArray();
+
+                result[matchingWord.Title] = englishDefinitions;
+            }
+
+            return result;
+        }
+
+        public async Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord)
+        {
+            var requests = definitionsByWord
+                .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
+                .GroupBy(kvp => kvp.Key.Trim(), StringComparer.CurrentCultureIgnoreCase)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.Last().Value.Trim(),
+                    StringComparer.CurrentCultureIgnoreCase);
+
+            var statuses = new Dictionary<string, string>();
+
+            if (requests.Count == 0)
+            {
+                return statuses;
+            }
+
+            var requestedWords = requests.Keys.ToArray();
+            var existingWords = await RepoCollection
+                .Find(Builders<WordEntry>.Filter.In(w => w.Title, requestedWords), SetCollationSecondary<FindOptions>(new FindOptions()))
+                .ToListAsync();
+
+            var existingByTitle = existingWords.ToDictionary(w => w.Title, StringComparer.CurrentCultureIgnoreCase);
+
+            foreach (var request in requests)
+            {
+                if (!existingByTitle.TryGetValue(request.Key, out var wordEntry))
+                {
+                    await CreateWord(request);
+                    statuses[request.Key] = "created";
+                    continue;
+                }
+
+                var definitionExists = wordEntry.Definitions.Any(d =>
+                    !string.IsNullOrWhiteSpace(d.EnglishTranslation)
+                    && string.Equals(d.EnglishTranslation.Trim(), request.Value, StringComparison.CurrentCultureIgnoreCase));
+
+                if (definitionExists)
+                {
+                    statuses[request.Key] = "skipped-duplicate";
+                    continue;
+                }
+
+                wordEntry.Definitions.Add(new Definition
+                {
+                    Content = YorubaDefinitionPlaceholder,
+                    EnglishTranslation = request.Value,
+                    NeedsReview = true
+                });
+
+                await RepoCollection.ReplaceOneAsync(
+                    Builders<WordEntry>.Filter.Eq(w => w.Id, wordEntry.Id),
+                    wordEntry);
+
+                statuses[request.Key] = "created";
+            }
+
+            return statuses;
+        }
+
+        private async Task CreateWord(KeyValuePair<string, string> request)
+        {
+            var newWordEntry = new WordEntry
+            {
+                Title = request.Key,
+                State = State.NEW,
+                Definitions = [new Definition
+                {
+                    Content = YorubaDefinitionPlaceholder,
+                    EnglishTranslation = request.Value,
+                    NeedsReview = true
+                }]
+            };
+
+            await RepoCollection.InsertOneAsync(newWordEntry);
         }
 
         // TODO YDict: Implement the custom FindBy methods (which are commented out in the interface) here (based on definitions).

--- a/Infrastructure/MongoDB/Repositories/Words/WordRepository.cs
+++ b/Infrastructure/MongoDB/Repositories/Words/WordRepository.cs
@@ -126,7 +126,7 @@ namespace Infrastructure.MongoDB.Repositories.Words
         }
 
         // TODO YDict: Test that this definition content search works as expected.
-        public async Task<HashSet<WordEntry>> FindEntryByDefinitionsContentContainingAndState(string title, State state)
+        public async Task<HashSet<WordEntry>> FindEntryByDefinitionsContentContainingAndStateAsync(string title, State state)
         {
             var filter = Builders<WordEntry>.Filter.ElemMatch(ne => ne.Definitions,
             Builders<Definition>.Filter.Regex(d => d.Content, new BsonRegularExpression(title.ReplaceYorubaVowelsWithPattern(), "i")))
@@ -135,7 +135,7 @@ namespace Infrastructure.MongoDB.Repositories.Words
             return [.. result];
         }
 
-        public async Task<IDictionary<string, string[]>> GetEnglishDefinitionsOf(IEnumerable<string> words)
+        public async Task<IDictionary<string, string[]>> GetEnglishDefinitionsOfAsync(IEnumerable<string> words)
         {
             var requestedWords = words
                 .Where(w => !string.IsNullOrWhiteSpace(w))
@@ -175,7 +175,7 @@ namespace Infrastructure.MongoDB.Repositories.Words
             return result;
         }
 
-        public async Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord)
+        public async Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord, string? currentUser = null)
         {
             var requests = definitionsByWord
                 .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
@@ -203,7 +203,7 @@ namespace Infrastructure.MongoDB.Repositories.Words
             {
                 if (!existingByTitle.TryGetValue(request.Key, out var wordEntry))
                 {
-                    await CreateWord(request);
+                    await CreateWord(request, currentUser);
                     statuses[request.Key] = "created";
                     continue;
                 }
@@ -224,6 +224,11 @@ namespace Infrastructure.MongoDB.Repositories.Words
                     EnglishTranslation = request.Value,
                     NeedsReview = true
                 });
+
+                if (!string.IsNullOrWhiteSpace(currentUser))
+                {
+                    wordEntry.UpdatedBy = currentUser;
+                }
 
                 await RepoCollection.ReplaceOneAsync(
                     Builders<WordEntry>.Filter.Eq(w => w.Id, wordEntry.Id),
@@ -260,7 +265,7 @@ namespace Infrastructure.MongoDB.Repositories.Words
             return aggregated;
         }
 
-        private async Task CreateWord(KeyValuePair<string, string> request)
+        private async Task CreateWord(KeyValuePair<string, string> request, string? currentUser)
         {
             var newWordEntry = new WordEntry
             {
@@ -274,7 +279,13 @@ namespace Infrastructure.MongoDB.Repositories.Words
                 }]
             };
 
-            await RepoCollection.InsertOneAsync(newWordEntry);
+            if (!string.IsNullOrWhiteSpace(currentUser))
+            {
+                newWordEntry.CreatedBy = currentUser;
+                newWordEntry.UpdatedBy = currentUser;
+            }
+
+            await Create(newWordEntry);
         }
 
         private bool EnsureIndexesCreated()

--- a/Words.Core/Dto/Response/DefinitionDto.cs
+++ b/Words.Core/Dto/Response/DefinitionDto.cs
@@ -1,6 +1,6 @@
 namespace Words.Core.Dto.Response
 {
-    public record DefinitionDto(string Content, string? EnglishTranslation, List<DefinitionExampleDto> Examples, DateTime SubmittedAt)
+    public record DefinitionDto(string Content, string? EnglishTranslation, List<DefinitionExampleDto> Examples, DateTime SubmittedAt, bool? NeedsReview = null)
     {
     }
 }

--- a/Words.Core/Dto/Response/WordDefinitionNeedsReviewDto.cs
+++ b/Words.Core/Dto/Response/WordDefinitionNeedsReviewDto.cs
@@ -1,0 +1,10 @@
+using YorubaOrganization.Core.Enums;
+
+namespace Words.Core.Dto.Response
+{
+    public record WordDefinitionNeedsReviewDto(
+        State State,
+        string WordTitle,
+        DateTime LastDefinitionAddedAt,
+        int DefinitionsNeedingReviewCount);
+}

--- a/Words.Core/Entities/Definition.cs
+++ b/Words.Core/Entities/Definition.cs
@@ -6,6 +6,7 @@ namespace Words.Core.Entities
     {
         public required string Content { get; set; }
         public string? EnglishTranslation { get; set; }
+        public bool? NeedsReview { get; set; }
         public List<DefinitionExample> Examples { get; set; } = [];
     }
 }

--- a/Words.Core/Repositories/IWordEntryRepository.cs
+++ b/Words.Core/Repositories/IWordEntryRepository.cs
@@ -7,6 +7,8 @@ namespace Words.Core.Repositories
     public interface IWordEntryRepository : IDictionaryEntryRepository<WordEntry>
     {
         Task<HashSet<WordEntry>> FindEntryByDefinitionsContentContainingAndState(string title, State state);
+        Task<IDictionary<string, string[]>> GetEnglishDefinitionsOf(IEnumerable<string> words);
+        Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord);
         Task<int> CountByStateAsync(State state);
         Task<List<WordEntry>> FindByStateAsync(State state);
         Task<WordEntry?> GetByIdAsync(string id);

--- a/Words.Core/Repositories/IWordEntryRepository.cs
+++ b/Words.Core/Repositories/IWordEntryRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Words.Core.Entities;
+using Words.Core.Dto.Response;
 using YorubaOrganization.Core.Enums;
 using YorubaOrganization.Core.Repositories;
 
@@ -9,6 +10,7 @@ namespace Words.Core.Repositories
         Task<HashSet<WordEntry>> FindEntryByDefinitionsContentContainingAndState(string title, State state);
         Task<IDictionary<string, string[]>> GetEnglishDefinitionsOf(IEnumerable<string> words);
         Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord);
+        Task<List<WordDefinitionNeedsReviewDto>> GetWordsWithDefinitionsNeedingReviewAsync(int page, int count);
         Task<int> CountByStateAsync(State state);
         Task<List<WordEntry>> FindByStateAsync(State state);
         Task<WordEntry?> GetByIdAsync(string id);

--- a/Words.Core/Repositories/IWordEntryRepository.cs
+++ b/Words.Core/Repositories/IWordEntryRepository.cs
@@ -7,9 +7,9 @@ namespace Words.Core.Repositories
 {
     public interface IWordEntryRepository : IDictionaryEntryRepository<WordEntry>
     {
-        Task<HashSet<WordEntry>> FindEntryByDefinitionsContentContainingAndState(string title, State state);
-        Task<IDictionary<string, string[]>> GetEnglishDefinitionsOf(IEnumerable<string> words);
-        Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord);
+        Task<HashSet<WordEntry>> FindEntryByDefinitionsContentContainingAndStateAsync(string title, State state);
+        Task<IDictionary<string, string[]>> GetEnglishDefinitionsOfAsync(IEnumerable<string> words);
+        Task<IDictionary<string, string>> AddEnglishDefinitionsAsync(IDictionary<string, string> definitionsByWord, string? currentUser = null);
         Task<List<WordDefinitionNeedsReviewDto>> GetWordsWithDefinitionsNeedingReviewAsync(int page, int count);
         Task<int> CountByStateAsync(State state);
         Task<List<WordEntry>> FindByStateAsync(State state);

--- a/Words.Website/Services/ApiService.cs
+++ b/Words.Website/Services/ApiService.cs
@@ -58,17 +58,17 @@ namespace Words.Website.Services
 
         public Task<WordEntryDto[]?> GetWordsByTitle(string wordEntry)
         {
-            return GetApiResponse<WordEntryDto[]?>($"/words/search/{Uri.EscapeDataString(wordEntry)}");
+            return GetFilteredWordsResponse($"/words/search/{Uri.EscapeDataString(wordEntry)}");
         }
 
         public Task<WordEntryDto[]?> GetAllWordsByAlphabet(string letter)
         {
-            return GetApiResponse<WordEntryDto[]?>($"/words/search/alphabet/{letter}");
+            return GetFilteredWordsResponse($"/words/search/alphabet/{letter}");
         }
 
         public Task<WordEntryDto[]?> SearchWordAsync(string query)
         {
-            return GetApiResponse<WordEntryDto[]?>($"/words/search?q={Uri.EscapeDataString(query)}");
+            return GetFilteredWordsResponse($"/words/search?q={Uri.EscapeDataString(query)}");
         }
 
         public Task<WordsMetadataDto?> GetIndexedWordCount()
@@ -103,6 +103,17 @@ namespace Words.Website.Services
                 }
                 throw new Exception("Error submitting word suggestion.");
             }
+        }
+
+        private async Task<WordEntryDto[]?> GetFilteredWordsResponse(string endpoint)
+        {
+            var words = await GetApiResponse<WordEntryDto[]?>(endpoint);
+            if (words == null)
+            {
+                return null;
+            }
+
+            return WordDefinitionFilter.KeepOnlyReviewedDefinitions(words);
         }
     }
 }

--- a/Words.Website/Services/WordDefinitionFilter.cs
+++ b/Words.Website/Services/WordDefinitionFilter.cs
@@ -1,0 +1,21 @@
+using Words.Core.Dto.Response;
+
+namespace Words.Website.Services
+{
+    internal static class WordDefinitionFilter
+    {
+        public static WordEntryDto[] KeepOnlyReviewedDefinitions(WordEntryDto[] words)
+        {
+            foreach (var word in words)
+            {
+                var filteredDefinitions = (word.Definitions ?? [])
+                    .Where(definition => definition.NeedsReview != true)
+                    .ToList();
+
+                word.Definitions = filteredDefinitions;
+            }
+
+            return words;
+        }
+    }
+}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -32,6 +32,9 @@ services:
     volumes:
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
       - ${APPDATA}/ASP.NET/Https:/root/.aspnet/https:ro
+    extra_hosts: 
+      - "local.yorubaword.com:127.0.0.1"
+
   mongodb:
     volumes:
       - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro

--- a/specs/english-definitions-review-workflow-spec.md
+++ b/specs/english-definitions-review-workflow-spec.md
@@ -76,6 +76,7 @@ Notes:
 - The response includes definitions irrespective of `NeedsReview` (`null`, `true`, `false`).
 - If a word is unknown, return an empty array for that word.
 - Word matching/casing/normalization should follow existing API word lookup behavior.
+- This endpoint should follow the same query-driven lookup pattern used by the existing `latest-meaning` endpoint in `Api.Controllers.Names.EtymologyController`.
 
 ### 4.2 POST `v1/words/definitions/in-english`
 

--- a/specs/english-definitions-review-workflow-spec.md
+++ b/specs/english-definitions-review-workflow-spec.md
@@ -1,0 +1,210 @@
+# English Definitions Review Workflow Spec
+
+- Date: 2026-05-10
+- Status: Draft
+- Repository: YorubaNameDictionary
+- Primary scope in this repository: API and Words Website
+- Context-only sections in this document: Dashboard and Migration (captured for cross-system alignment)
+
+## 1. Purpose
+
+This specification introduces an English definitions workflow that allows new English definitions to be captured without immediate public display, then reviewed and approved before being shown on the Words website.
+
+The workflow is designed to:
+- Preserve existing definitions and behavior for current data.
+- Support fetching multiple existing English definitions per word.
+- Support creating proposed definitions that require review.
+- Ensure website display excludes unreviewed definitions.
+- Keep Dashboard and Migration requirements visible for downstream implementation in related systems.
+
+## 2. Scope
+
+### In scope for this repository
+- API changes for definition review metadata and English-definitions endpoints.
+- Words Website display rule update to hide unreviewed definitions.
+- Specification folder setup for future spec-driven development.
+
+### Out of direct implementation scope for this repository (context only)
+- Names Dashboard changes.
+- Words Dashboard editor enhancements.
+- Migration execution from Yoruba Name and Yoruba Word dictionary etymologies.
+
+## 3. Domain Model Changes (API)
+
+### Definition object
+Add field:
+- `NeedsReview: boolean | null`
+
+Behavior:
+- Existing definitions remain unchanged and can have `NeedsReview = null`.
+- New definitions created through the new POST endpoint must set `NeedsReview = true`.
+- Reviewed definitions (set by dashboard/editor flows outside this repo scope) are expected to move to `NeedsReview = false`.
+
+Compatibility:
+- No manual migration required for existing records.
+- Null must be treated as legacy state.
+
+## 4. API Requirements
+
+Base path prefix is existing API versioning (`v1`).
+
+### 4.1 GET `v1/words/definitions/in-english?q={array-of-words}`
+
+#### Intent
+Return all existing English definitions for each requested word, regardless of `NeedsReview` status.
+
+#### Request
+- Method: `GET`
+- Route: `v1/words/definitions/in-english`
+- Query param:
+  - `q`: array of words
+
+#### Response
+- `200 OK` with dictionary/object:
+  - key: word
+  - value: array of English definitions
+
+Example response:
+```json
+{
+  "omo": ["child", "offspring", "human being"],
+  "ife": ["love", "affection"]
+}
+```
+
+Notes:
+- The response includes definitions irrespective of `NeedsReview` (`null`, `true`, `false`).
+- If a word is unknown, return an empty array for that word.
+- Word matching/casing/normalization should follow existing API word lookup behavior.
+
+### 4.2 POST `v1/words/definitions/in-english`
+
+#### Intent
+Create new English definitions that do not already exist for each supplied word, and mark each created definition as review-required.
+
+#### Request
+- Method: `POST`
+- Route: `v1/words/definitions/in-english`
+- Body: dictionary/object where:
+  - key: word
+  - value: new English definition (string)
+
+Example request:
+```json
+{
+  "ife": "deep fondness",
+  "iwa": "character disposition"
+}
+```
+
+#### Behavior
+- For each `(word, definition)` pair:
+  - If the definition does not exist for the word, create it with `NeedsReview = true`.
+  - If the definition already exists, do not duplicate it.
+- Endpoint is complementary to the GET endpoint and uses the same word semantics.
+
+#### Response
+- `200 OK` or `201 Created` based on existing API conventions.
+- Should include per-word outcome details (created, skipped-duplicate, not-found) to support dashboard workflows.
+
+Suggested response shape:
+```json
+{
+  "ife": { "status": "created" },
+  "iwa": { "status": "created" },
+  "omo": { "status": "skipped-duplicate" }
+}
+```
+
+## 5. Words Website Requirements
+
+Display rule update:
+- Only definitions where `NeedsReview = false` are shown on the website.
+
+Handling legacy records:
+- Definitions with `NeedsReview = null` are legacy values.
+- This spec follows the explicit requirement: only `false` is displayable.
+- If legacy null values currently appear in production, product alignment is required before rollout to avoid unintended content hiding.
+
+## 6. Dashboard Requirements (Context Only)
+
+These requirements are documented for dependent systems and integrations:
+
+1. Add page listing words that contain at least one definition with review-needed state.
+2. Names dashboard etymology meaning flow moves from latest-meaning lookup to new english-definitions endpoint:
+- User can cycle through returned definitions for each etymology part.
+- Manual etymology part entry auto-fetches definitions and auto-selects first definition.
+- Glossary-generated etymology parts fetch definitions in batch and auto-select first value per part.
+3. If user enters a meaning not in existing definitions, submit via POST `v1/words/definitions/in-english`.
+4. Words dashboard should populate etymology meaning using the same endpoint.
+5. Names and Words editor create/edit:
+- For any definition with `NeedsReview = true`, show `Reviewed` checkbox.
+- Do not show checkbox for `NeedsReview = null` or `false`.
+- Form cannot be submitted until all shown `Reviewed` checkboxes are checked.
+6. Before publish, show final warning listing reviewed definitions that will become publicly visible.
+7. Extend etymology population behavior to create page in both dashboards.
+
+## 7. Migration Requirements (Context Only)
+
+Apply the same migration pattern to:
+- Yoruba Name dictionary etymologies
+- Yoruba Word dictionary etymologies
+
+Algorithm:
+1. Existing word:
+- Add new definition with English translation value.
+- Mark added definition as review-needed (not publicly visible until reviewed/expanded).
+- Do not unpublish word.
+- Tag word with `Definition(s) Need Review`.
+2. New word:
+- Create new word entry with `state = NEW`, `partOfSpeech = UNKNOWN`.
+- Include migrated definition.
+- Tag with `Definitions Need Review`.
+3. Preserve all existing definitions.
+4. Deduplicate English translations.
+
+## 8. Acceptance Criteria
+
+### API
+1. Existing records remain valid without migration scripts.
+2. GET endpoint returns dictionary mapping each requested word to all English definitions regardless of review status.
+3. POST endpoint creates only non-existing definitions and sets `NeedsReview = true` for created entries.
+4. Duplicate submissions do not create duplicate definitions.
+
+### Words Website
+1. Website renders only definitions with `NeedsReview = false`.
+2. Definitions with `NeedsReview = true` are never displayed publicly.
+3. Behavior for `NeedsReview = null` follows explicit product decision documented in this spec.
+
+## 9. Testing Guidance
+
+### API tests
+- GET endpoint:
+  - returns all statuses (`null`, `true`, `false`) in response values.
+  - handles unknown words with empty arrays.
+- POST endpoint:
+  - creates new definition with `NeedsReview = true`.
+  - skips duplicate definitions.
+  - handles mixed outcomes in one request.
+
+### Website tests
+- Confirm only `NeedsReview = false` definitions render.
+- Confirm `true` and `null` definitions are excluded.
+
+## 10. Open Questions
+
+1. Query serialization for `q` array in GET endpoint:
+- Repeated query keys (`?q=ife&q=iwa`) vs comma-separated (`?q=ife, iwa`) vs JSON array string.
+2. Response contract for POST outcomes:
+- Final status code and exact payload schema.
+3. Should unknown words in POST auto-create words or return not-found (current spec assumes outcome reporting without enforcing creation).
+4. Final product confirmation on website behavior for legacy `NeedsReview = null` definitions.
+
+## 11. Future Spec-Driven Development Convention
+
+This repository will store new product/engineering specs under:
+- `specs/`
+
+Recommended filename format:
+- `YYYY-MM-DD-short-feature-name-spec.md` for time-based traceability, or
+- `short-feature-name-spec.md` for stable long-lived specs.

--- a/specs/english-definitions-review-workflow-spec.md
+++ b/specs/english-definitions-review-workflow-spec.md
@@ -120,7 +120,7 @@ Suggested response shape:
 ## 5. Words Website Requirements
 
 Display rule update:
-- Only definitions where `NeedsReview = false` are shown on the website.
+- Only definitions where `NeedsReview != true` are shown on the website.
 
 Handling legacy records:
 - Definitions with `NeedsReview = null` are legacy values.


### PR DESCRIPTION
In this feature, we create API endpoints for programmatic access to English definitions in the YorubaWord dictionary.

Additionally, in the Yoruba Names etymology endpoint, we change the source of etymology meanings from other names in the same database to the new Yoruba Word English definitions endpoints.

In addition, there is now an endpoint through which etymology meanings added added via Yoruba Names to make their way to Yoruba Word English definitions (for further review).