### PR TITLE
Fix link to Yoruba keyboard software

### DIFF
--- a/Website/Pages/Shared/_Layout.cshtml
+++ b/Website/Pages/Shared/_Layout.cshtml
@@ -166,7 +166,7 @@
                         </p>
                         
                         <div class="mt-auto">
-                            <a class="btn btn-cta-gold" href="/keyboard">
+                            <a class="btn btn-cta-gold" href="https://www.writeyoruba.com" target="_blank">
                                 Get the Software <i class="bi bi-arrow-right ms-2"></i>
                             </a>
                         </div>


### PR DESCRIPTION
The previous link to download the keyboard was broken. Changing it to lead to the right destination (writeyoruba.com).